### PR TITLE
Ocd3 remove hyphen from on request

### DIFF
--- a/.github/workflows/revalidate.yaml
+++ b/.github/workflows/revalidate.yaml
@@ -1,7 +1,7 @@
 name: revalidate-data
 on:
   schedule:
-    - cron: '0 * * * *'
+    - cron: '0/5 * * * *'
 jobs:
   cron:
     runs-on: ubuntu-latest

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -389,7 +389,7 @@ const strings_en = {
         },
         tagShort: {
             [Tag.LeadSupporter]: 'supporter',
-            [Tag.OnRequest]: 'on-request',
+            [Tag.OnRequest]: 'on request',
             [Tag.Online]: 'online',
             [Tag.SellUkrainianProducts]: 'Ukrainian product',
             [Tag.UkrainianOwned]: 'owned'


### PR DESCRIPTION
# Overview
Did a find-and-replace for on-request and changed it to on request in the one location it was found

# Ticket

[*A link to the associated Notion ticket*](https://www.notion.so/shop4ua/Change-the-on-request-tag-to-have-no-hyphen-0cd31b16da8f4ffabea747b8e25062ef?pvs=4)

# Screenshots

<img width="367" alt="image" src="https://user-images.githubusercontent.com/57777918/230125479-85c6392d-611c-4b47-9a03-99b5a31f6f09.png">

# Testing

Change was reflected when run

# Notes

As far as I understand, this change does not affect unpacking from Airtable and that this is the only place we define the tag.

<br>