### PR TITLE
d25d - Tag tooltips should have full explanations

### DIFF
--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -381,11 +381,11 @@ const strings_en = {
             toastSuccessCopy: 'Copied link',
         },
         tag: {
-            [Tag.LeadSupporter]: 'Lead Supporter',
-            [Tag.OnRequest]: 'On Request',
-            [Tag.Online]: 'Online',
-            [Tag.SellUkrainianProducts]: 'Sell Ukrainian Products',
-            [Tag.UkrainianOwned]: 'Ukrainian-Owned'
+            [Tag.LeadSupporter]: 'Businesses that did significant contributions to Ukrainian community, fundraising, and in other ways.',
+            [Tag.OnRequest]: 'All services and products are offered in person but not through a physical location.',
+            [Tag.Online]: 'All services and products are offered online only and with deliveries if applicable.',
+            [Tag.SellUkrainianProducts]: 'Offers Ukrainian services and products made by Ukrainians or imported from Ukraine.',
+            [Tag.UkrainianOwned]: 'Ukraine owned: Ukrainian immigrants, Ukrainian family, Ukrainian Americans with strong Ukrainian ties.'
         },
         tagShort: {
             [Tag.LeadSupporter]: 'supporter',

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -385,7 +385,7 @@ const strings_en = {
             [Tag.OnRequest]: 'All services and products are offered in person but not through a physical location.',
             [Tag.Online]: 'All services and products are offered online only and with deliveries if applicable.',
             [Tag.SellUkrainianProducts]: 'Offers Ukrainian services and products made by Ukrainians or imported from Ukraine.',
-            [Tag.UkrainianOwned]: 'Ukraine owned: Ukrainian immigrants, Ukrainian family, Ukrainian Americans with strong Ukrainian ties.'
+            [Tag.UkrainianOwned]: 'Ukrainian-owned: Ukrainian immigrants, Ukrainian family, Ukrainian Americans with strong Ukrainian ties.'
         },
         tagShort: {
             [Tag.LeadSupporter]: 'supporter',

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -381,7 +381,7 @@ const strings_en = {
             toastSuccessCopy: 'Copied link',
         },
         tag: {
-            [Tag.LeadSupporter]: 'Businesses that did significant contributions to Ukrainian community, fundraising, and in other ways.',
+            [Tag.LeadSupporter]: 'Businesses that made significant contributions to the Ukrainian community: fundraising, event support, donation, and in other ways.',
             [Tag.OnRequest]: 'All services and products are offered in person but not through a physical location.',
             [Tag.Online]: 'All services and products are offered online only and with deliveries if applicable.',
             [Tag.SellUkrainianProducts]: 'Offers Ukrainian services and products made by Ukrainians or imported from Ukraine.',


### PR DESCRIPTION
# Overview

Updated tooltip descriptions to match those in database design so that they provide more useful information.

# Ticket

https://www.notion.so/shop4ua/Tag-tooltips-should-have-full-explanations-d25d24540a3245ffb4bbabdac0f3757f?pvs=4

# Screenshots

<img width="408" alt="image" src="https://user-images.githubusercontent.com/57777918/231507645-19f59ef1-d80e-4ae8-a842-cc4f7975ad14.png">
<img width="341" alt="image" src="https://user-images.githubusercontent.com/57777918/231507708-c6f91783-25dc-421d-af68-37e4b3f9a0f6.png">


# Testing

Checked each of the tooltips in the /businesses page that they had the updated tooltip.

<br>